### PR TITLE
Remove dependency to gl-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ license = "CC0-1.0"
 repository = "https://github.com/Daggerbot/osmesa-rs.git"
 
 [dependencies]
-gl = "*"
 libc = "*"
 shared_library = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,13 @@
 
 #[macro_use]
 extern crate shared_library;
-extern crate gl;
 extern crate libc;
 
-use gl::types::{
-  GLboolean,
-  GLenum,
-  GLint,
-  GLsizei,
-};
+type GLboolean = libc::c_uchar;
+type GLenum = libc::c_uint;
+type GLint = libc::c_int;
+type GLsizei = libc::c_int;
+
 use libc::{
   c_char,
   c_void,


### PR DESCRIPTION
Close #3 

Building `gl-rs` generates a lot of code, and we just need 4 typedefs.
This wouldn't be a problem, but most code that uses OpenGL doesn't depend on `gl-rs` but generate their own bindings.
